### PR TITLE
fix: Dockerfile and custom nginx configuration for web server setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,13 @@
 FROM nginx:alpine
+
+# Copy website files
 COPY www /usr/share/nginx/html
+
+# Copy custom nginx config
+COPY nginx.conf /etc/nginx/templates/default.conf.template
+
+# Set environment variable for templates
+ENV NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx/conf.d
+
+# Expose the port
+EXPOSE 8080

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,10 @@
+server {
+    listen ${PORT};
+    server_name localhost;
+    
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.html;
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
This pull request includes changes to the `Dockerfile` and the addition of a custom `nginx.conf` file to set up a custom Nginx configuration for serving a website. The most important changes include copying website files, adding a custom Nginx configuration, setting environment variables, and exposing a port.

Changes to `Dockerfile`:

* Added commands to copy website files to the Nginx HTML directory.
* Added commands to copy a custom Nginx configuration file.
* Set an environment variable for Nginx templates.
* Exposed port 8080 for the Nginx server.

Addition of `nginx.conf`:

* Added a custom Nginx configuration file to set up the server to listen on a specified port and serve the website files.

---

Closes #54 